### PR TITLE
Add basic notes management

### DIFF
--- a/cache/notes_form.php
+++ b/cache/notes_form.php
@@ -1,0 +1,47 @@
+<?php class_exists('app\core\Template') or exit; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Note</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/css/style.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="/notes">Notes App</a>
+    </div>
+</nav>
+<div class="container mb-5">
+
+<h2 class="mb-3"><?php if ($is_edit) { ?>Edit<?php } else { ?>Create<?php } ?> Note</h2>
+<form method="post" action="<?= $action ?>">
+    <input type="hidden" name="id" value="<?= $note_id ?>">
+    <div class="mb-3">
+        <label class="form-label">Title</label>
+        <input class="form-control" type="text" name="title" value="<?= $title ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Description</label>
+        <textarea class="form-control" name="description"><?= $description ?></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Color</label>
+        <input class="form-control" type="text" name="color" value="<?= $color ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Tags</label>
+        <input class="form-control" type="text" name="tags" value="<?= $tags ?>">
+    </div>
+    <button class="btn btn-primary" type="submit">Save</button>
+</form>
+
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+
+
+
+

--- a/cache/notes_index.php
+++ b/cache/notes_index.php
@@ -1,0 +1,61 @@
+<?php class_exists('app\core\Template') or exit; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Notes</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/css/style.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="/notes">Notes App</a>
+    </div>
+</nav>
+<div class="container mb-5">
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Notes</h2>
+    <a class="btn btn-primary" href="/notes/create">Add note</a>
+</div>
+
+<form class="row g-2 mb-4" method="get" action="/notes">
+    <div class="col-md-4">
+        <input class="form-control" type="text" name="q" placeholder="search" value="<?= $filters['q'] ?>">
+    </div>
+    <div class="col-md-3">
+        <input class="form-control" type="text" name="tag" placeholder="tag" value="<?= $filters['tag'] ?>">
+    </div>
+    <div class="col-md-3">
+        <input class="form-control" type="text" name="color" placeholder="color" value="<?= $filters['color'] ?>">
+    </div>
+    <div class="col-md-2">
+        <button class="btn btn-secondary w-100" type="submit">Filter</button>
+    </div>
+</form>
+
+<div class="row row-cols-1 g-3">
+<?php foreach ($notes as $note) { ?>
+    <div class="col">
+        <div class="card" style="border-left: 6px solid <?= $note->getColor() ?>;">
+            <div class="card-body">
+                <h5 class="card-title"><?= $note->getTitle() ?></h5>
+                <p class="card-text"><?= $note->getDescription() ?></p>
+                <p class="card-text"><small class="text-muted">Tags: <?= $note->getTags() ?> | Created: <?= $note->getCreatedAt() ?></small></p>
+                <a class="btn btn-sm btn-outline-primary" href="/notes/edit?id=<?= $note->getId() ?>">Edit</a>
+                <a class="btn btn-sm btn-outline-danger" href="/notes/delete?id=<?= $note->getId() ?>">Delete</a>
+            </div>
+        </div>
+    </div>
+<?php } ?>
+</div>
+
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+
+
+
+

--- a/cache/notes_success.php
+++ b/cache/notes_success.php
@@ -1,0 +1,28 @@
+<?php class_exists('app\core\Template') or exit; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Success</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/css/style.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="/notes">Notes App</a>
+    </div>
+</nav>
+<div class="container mb-5">
+
+<div class="alert alert-success" role="alert">
+    Success!
+</div>
+<a class="btn btn-link" href="/notes">Back</a>
+
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+
+

--- a/console/migrate.php
+++ b/console/migrate.php
@@ -11,7 +11,7 @@ chdir(PROJECT_ROOT);
 
 require PROJECT_ROOT . "vendor/autoload.php";
 
-include 'migrations\AllMigrations.php';
+include PROJECT_ROOT . 'migrations/AllMigrations.php';
 $migrations = getMigrations();
 echo sprintf("%s migrations found%s", count($migrations), PHP_EOL);
 

--- a/controllers/NoteController.php
+++ b/controllers/NoteController.php
@@ -17,7 +17,7 @@ class NoteController
         $this->mapper = new NoteMapper();
     }
 
-    public function index()
+    public function index(): void
     {
         $body = Application::$app->getRequest()->getBody();
         $query = $body['q'] ?? null;
@@ -31,7 +31,7 @@ class NoteController
         ]);
     }
 
-    public function createView()
+    public function createView(): void
     {
         Application::$app->getRouter()->renderTemplate('notes/form', [
             'action' => '/notes/create',
@@ -44,7 +44,7 @@ class NoteController
         ]);
     }
 
-    public function create()
+    public function create(): void
     {
         $body = Application::$app->getRequest()->getBody();
         $note = new Note(
@@ -58,7 +58,7 @@ class NoteController
         Application::$app->getRouter()->renderTemplate('notes/success', []);
     }
 
-    public function editView()
+    public function editView(): void
     {
         $body = Application::$app->getRequest()->getBody();
         if (!isset($body['id'])) {
@@ -83,7 +83,7 @@ class NoteController
         ]);
     }
 
-    public function edit()
+    public function edit(): void
     {
         $body = Application::$app->getRequest()->getBody();
         if (!isset($body['id'])) {
@@ -101,7 +101,7 @@ class NoteController
         Application::$app->getRouter()->renderTemplate('notes/success', []);
     }
 
-    public function delete()
+    public function delete(): void
     {
         $body = Application::$app->getRequest()->getBody();
         if (isset($body['id'])) {

--- a/controllers/NoteController.php
+++ b/controllers/NoteController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\controllers;
+
+use app\core\Application;
+use app\mappers\NoteMapper;
+use app\models\Note;
+
+class NoteController
+{
+    private NoteMapper $mapper;
+
+    public function __construct()
+    {
+        $this->mapper = new NoteMapper();
+    }
+
+    public function index()
+    {
+        $body = Application::$app->getRequest()->getBody();
+        $query = $body['q'] ?? null;
+        $tag = $body['tag'] ?? null;
+        $color = $body['color'] ?? null;
+        $rows = $this->mapper->filter($query, $tag, $color);
+        $notes = array_map(fn($row) => $this->mapper->createObject($row), $rows);
+        Application::$app->getRouter()->renderTemplate('notes/index', [
+            'notes' => $notes,
+            'filters' => ['q' => $query, 'tag' => $tag, 'color' => $color]
+        ]);
+    }
+
+    public function createView()
+    {
+        Application::$app->getRouter()->renderTemplate('notes/form', [
+            'action' => '/notes/create',
+            'title' => '',
+            'description' => '',
+            'color' => '',
+            'tags' => '',
+            'note_id' => '',
+            'is_edit' => false,
+        ]);
+    }
+
+    public function create()
+    {
+        $body = Application::$app->getRequest()->getBody();
+        $note = new Note(
+            id: null,
+            title: $body['title'] ?? '',
+            description: $body['description'] ?? '',
+            color: $body['color'] ?? '',
+            tags: $body['tags'] ?? ''
+        );
+        $this->mapper->Insert($note);
+        Application::$app->getRouter()->renderTemplate('notes/success', []);
+    }
+
+    public function editView()
+    {
+        $body = Application::$app->getRequest()->getBody();
+        if (!isset($body['id'])) {
+            Application::$app->getRouter()->renderStatic('404.html');
+            return;
+        }
+        $row = $this->mapper->doSelect((int)$body['id']);
+        if (!$row) {
+            Application::$app->getRouter()->renderStatic('404.html');
+            return;
+        }
+        /** @var Note $note */
+        $note = $this->mapper->createObject($row);
+        Application::$app->getRouter()->renderTemplate('notes/form', [
+            'action' => '/notes/edit',
+            'title' => $note->getTitle(),
+            'description' => $note->getDescription(),
+            'color' => $note->getColor(),
+            'tags' => $note->getTags(),
+            'note_id' => $note->getId(),
+            'is_edit' => true,
+        ]);
+    }
+
+    public function edit()
+    {
+        $body = Application::$app->getRequest()->getBody();
+        if (!isset($body['id'])) {
+            Application::$app->getRouter()->renderStatic('404.html');
+            return;
+        }
+        $note = new Note(
+            id: (int)$body['id'],
+            title: $body['title'] ?? '',
+            description: $body['description'] ?? '',
+            color: $body['color'] ?? '',
+            tags: $body['tags'] ?? ''
+        );
+        $this->mapper->Update($note);
+        Application::$app->getRouter()->renderTemplate('notes/success', []);
+    }
+
+    public function delete()
+    {
+        $body = Application::$app->getRequest()->getBody();
+        if (isset($body['id'])) {
+            $note = new Note((int)$body['id'], '', '', '', '');
+            $this->mapper->Delete($note);
+        }
+        Application::$app->getRouter()->renderTemplate('notes/success', []);
+    }
+}

--- a/core/Mapper.php
+++ b/core/Mapper.php
@@ -41,7 +41,7 @@ abstract class Mapper
 
     protected abstract function doDelete(Model $model);
 
-    protected abstract function doSelect(int $id): array;
+    abstract public function doSelect(int $id): array;
 
     protected abstract function doSelectAll(): array;
 

--- a/core/Request.php
+++ b/core/Request.php
@@ -8,7 +8,12 @@ class Request
 {
     public function getUri(): string
     {
-        return $_SERVER["REQUEST_URI"];
+        $uri = $_SERVER["REQUEST_URI"] ?? '/';
+        $pos = strpos($uri, '?');
+        if ($pos !== false) {
+            $uri = substr($uri, 0, $pos);
+        }
+        return $uri;
     }
 
     public function getMethod(): MethodEnum

--- a/mappers/NoteMapper.php
+++ b/mappers/NoteMapper.php
@@ -65,7 +65,7 @@ class NoteMapper extends Mapper
         $this->delete->execute([':id' => $model->getId()]);
     }
 
-    protected function doSelect(int $id): array
+    public function doSelect(int $id): array
     {
         $this->select->execute([':id' => $id]);
         return $this->select->fetch(\PDO::FETCH_ASSOC) ?: [];

--- a/mappers/NoteMapper.php
+++ b/mappers/NoteMapper.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\mappers;
+
+use app\core\Mapper;
+use app\core\Model;
+use app\models\Note;
+
+class NoteMapper extends Mapper
+{
+    private ?\PDOStatement $insert;
+    private ?\PDOStatement $update;
+    private ?\PDOStatement $delete;
+    private ?\PDOStatement $select;
+    private ?\PDOStatement $selectAll;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->insert = $this->getPdo()->prepare(
+            "INSERT INTO notes (title, description, color, tags) VALUES (:title, :description, :color, :tags)"
+        );
+
+        $this->update = $this->getPdo()->prepare(
+            "UPDATE notes SET title = :title, description = :description, color = :color, tags = :tags, updated_at = current_timestamp WHERE id = :id"
+        );
+
+        $this->delete = $this->getPdo()->prepare("DELETE FROM notes WHERE id = :id");
+
+        $this->select = $this->getPdo()->prepare("SELECT * FROM notes WHERE id = :id");
+
+        $this->selectAll = $this->getPdo()->prepare("SELECT * FROM notes ORDER BY created_at DESC");
+    }
+
+    protected function doInsert(Model $model): Model
+    {
+        /** @var Note $model */
+        $this->insert->execute([
+            ':title' => $model->getTitle(),
+            ':description' => $model->getDescription(),
+            ':color' => $model->getColor(),
+            ':tags' => $model->getTags(),
+        ]);
+        $model->setId((int)$this->getPdo()->lastInsertId());
+        return $model;
+    }
+
+    protected function doUpdate(Model $model)
+    {
+        /** @var Note $model */
+        $this->update->execute([
+            ':id' => $model->getId(),
+            ':title' => $model->getTitle(),
+            ':description' => $model->getDescription(),
+            ':color' => $model->getColor(),
+            ':tags' => $model->getTags(),
+        ]);
+    }
+
+    protected function doDelete(Model $model)
+    {
+        $this->delete->execute([':id' => $model->getId()]);
+    }
+
+    protected function doSelect(int $id): array
+    {
+        $this->select->execute([':id' => $id]);
+        return $this->select->fetch(\PDO::FETCH_ASSOC) ?: [];
+    }
+
+    protected function doSelectAll(): array
+    {
+        $this->selectAll->execute();
+        return $this->selectAll->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public function getInstance(): Mapper
+    {
+        return $this;
+    }
+
+    public function createObject(array $data): Model
+    {
+        return new Note(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? '',
+            description: $data['description'] ?? '',
+            color: $data['color'] ?? '',
+            tags: $data['tags'] ?? '',
+            created_at: $data['created_at'] ?? '',
+            updated_at: $data['updated_at'] ?? ''
+        );
+    }
+
+    public function filter(?string $query = null, ?string $tag = null, ?string $color = null): array
+    {
+        $sql = 'SELECT * FROM notes WHERE 1=1';
+        $params = [];
+        if ($query) {
+            $sql .= ' AND (title ILIKE :query OR description ILIKE :query)';
+            $params[':query'] = '%' . $query . '%';
+        }
+        if ($tag) {
+            $sql .= ' AND tags ILIKE :tag';
+            $params[':tag'] = '%' . $tag . '%';
+        }
+        if ($color) {
+            $sql .= ' AND color = :color';
+            $params[':color'] = $color;
+        }
+        $sql .= ' ORDER BY created_at DESC';
+        $stmt = $this->getPdo()->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+}

--- a/mappers/UserMapper.php
+++ b/mappers/UserMapper.php
@@ -87,7 +87,7 @@ class UserMapper extends \app\core\Mapper
        $this->delete->execute([":id"=>$model->getId()]);
     }
 
-    protected function doSelect(int $id): array
+    public function doSelect(int $id): array
     {
         $this->select->execute([":id"=>$id]);
        return $this->select->fetch(\PDO::FETCH_NAMED);

--- a/migrations/AllMigrations.php
+++ b/migrations/AllMigrations.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use app\migrations\{Migration_0, Migration_1, Migration_2};
+use app\migrations\{Migration_0, Migration_1, Migration_2, Migration_3};
 
 function getMigrations(): array
 {
-    return [new Migration_0(), new Migration_1(), new Migration_2()];
+    return [new Migration_0(), new Migration_1(), new Migration_2(), new Migration_3()];
 }

--- a/migrations/Migration_3.php
+++ b/migrations/Migration_3.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\migrations;
+
+class Migration_3 extends \app\core\Migration
+{
+    public function getVersion(): int
+    {
+        return 3;
+    }
+
+    public function up(): void
+    {
+        $this->database->pdo->query("CREATE TABLE IF NOT EXISTS notes (
+            id serial primary key,
+            title varchar(255) not null,
+            description text not null,
+            color varchar(50) not null,
+            tags varchar(255) not null,
+            created_at timestamp not null default CURRENT_TIMESTAMP,
+            updated_at timestamp not null default CURRENT_TIMESTAMP
+        );");
+
+        parent::up();
+    }
+}

--- a/models/Note.php
+++ b/models/Note.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use app\core\Model;
+
+class Note extends Model
+{
+    private string $title;
+    private string $description;
+    private string $color;
+    private string $tags;
+    private string $created_at;
+    private string $updated_at;
+
+    public function __construct(?int $id,
+                                string $title,
+                                string $description,
+                                string $color,
+                                string $tags,
+                                string $created_at = '',
+                                string $updated_at = '')
+    {
+        parent::__construct($id);
+        $this->title = $title;
+        $this->description = $description;
+        $this->color = $color;
+        $this->tags = $tags;
+        $this->created_at = $created_at;
+        $this->updated_at = $updated_at;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getColor(): string
+    {
+        return $this->color;
+    }
+
+    public function setColor(string $color): void
+    {
+        $this->color = $color;
+    }
+
+    public function getTags(): string
+    {
+        return $this->tags;
+    }
+
+    public function setTags(string $tags): void
+    {
+        $this->tags = $tags;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->created_at;
+    }
+
+    public function setCreatedAt(string $created_at): void
+    {
+        $this->created_at = $created_at;
+    }
+
+    public function getUpdatedAt(): string
+    {
+        return $this->updated_at;
+    }
+
+    public function setUpdatedAt(string $updated_at): void
+    {
+        $this->updated_at = $updated_at;
+    }
+}

--- a/views/layout.html
+++ b/views/layout.html
@@ -3,8 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <title>{% yield title %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="/notes">Notes App</a>
+    </div>
+</nav>
+<div class="container mb-5">
 {% yield content %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/views/notes/form.html
+++ b/views/notes/form.html
@@ -1,0 +1,19 @@
+{% extends layout.html %}
+
+{% block title %}Note{% endblock %}
+
+{% block content %}
+<h2>{% if ($is_edit) { %}Edit{% } else { %}Create{% } %} Note</h2>
+<form method="post" action="{{ $action }}">
+    <input type="hidden" name="id" value="{{ $note_id }}">
+    <label>Title</label><br>
+    <input type="text" name="title" value="{{ $title }}"><br>
+    <label>Description</label><br>
+    <textarea name="description">{{ $description }}</textarea><br>
+    <label>Color</label><br>
+    <input type="text" name="color" value="{{ $color }}"><br>
+    <label>Tags</label><br>
+    <input type="text" name="tags" value="{{ $tags }}"><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/views/notes/form.html
+++ b/views/notes/form.html
@@ -3,17 +3,25 @@
 {% block title %}Note{% endblock %}
 
 {% block content %}
-<h2>{% if ($is_edit) { %}Edit{% } else { %}Create{% } %} Note</h2>
+<h2 class="mb-3">{% if ($is_edit) { %}Edit{% } else { %}Create{% } %} Note</h2>
 <form method="post" action="{{ $action }}">
     <input type="hidden" name="id" value="{{ $note_id }}">
-    <label>Title</label><br>
-    <input type="text" name="title" value="{{ $title }}"><br>
-    <label>Description</label><br>
-    <textarea name="description">{{ $description }}</textarea><br>
-    <label>Color</label><br>
-    <input type="text" name="color" value="{{ $color }}"><br>
-    <label>Tags</label><br>
-    <input type="text" name="tags" value="{{ $tags }}"><br>
-    <button type="submit">Save</button>
+    <div class="mb-3">
+        <label class="form-label">Title</label>
+        <input class="form-control" type="text" name="title" value="{{ $title }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Description</label>
+        <textarea class="form-control" name="description">{{ $description }}</textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Color</label>
+        <input class="form-control" type="text" name="color" value="{{ $color }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Tags</label>
+        <input class="form-control" type="text" name="tags" value="{{ $tags }}">
+    </div>
+    <button class="btn btn-primary" type="submit">Save</button>
 </form>
 {% endblock %}

--- a/views/notes/index.html
+++ b/views/notes/index.html
@@ -1,0 +1,24 @@
+{% extends layout.html %}
+
+{% block title %}Notes{% endblock %}
+
+{% block content %}
+<h2>Notes</h2>
+<a href="/notes/create">Add note</a>
+<form method="get" action="/notes">
+    <input type="text" name="q" placeholder="search" value="{{ $filters['q'] }}">
+    <input type="text" name="tag" placeholder="tag" value="{{ $filters['tag'] }}">
+    <input type="text" name="color" placeholder="color" value="{{ $filters['color'] }}">
+    <button type="submit">Filter</button>
+</form>
+<ul>
+{% foreach ($notes as $note) { %}
+    <li style="border-left: 4px solid {{ $note->getColor() }}; margin:5px; padding:5px;">
+        <strong>{{ $note->getTitle() }}</strong> - {{ $note->getDescription() }}<br>
+        <small>Tags: {{ $note->getTags() }} | Created: {{ $note->getCreatedAt() }}</small><br>
+        <a href="/notes/edit?id={{ $note->getId() }}">Edit</a>
+        <a href="/notes/delete?id={{ $note->getId() }}">Delete</a>
+    </li>
+{% } %}
+</ul>
+{% endblock %}

--- a/views/notes/index.html
+++ b/views/notes/index.html
@@ -3,22 +3,39 @@
 {% block title %}Notes{% endblock %}
 
 {% block content %}
-<h2>Notes</h2>
-<a href="/notes/create">Add note</a>
-<form method="get" action="/notes">
-    <input type="text" name="q" placeholder="search" value="{{ $filters['q'] }}">
-    <input type="text" name="tag" placeholder="tag" value="{{ $filters['tag'] }}">
-    <input type="text" name="color" placeholder="color" value="{{ $filters['color'] }}">
-    <button type="submit">Filter</button>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Notes</h2>
+    <a class="btn btn-primary" href="/notes/create">Add note</a>
+</div>
+
+<form class="row g-2 mb-4" method="get" action="/notes">
+    <div class="col-md-4">
+        <input class="form-control" type="text" name="q" placeholder="search" value="{{ $filters['q'] }}">
+    </div>
+    <div class="col-md-3">
+        <input class="form-control" type="text" name="tag" placeholder="tag" value="{{ $filters['tag'] }}">
+    </div>
+    <div class="col-md-3">
+        <input class="form-control" type="text" name="color" placeholder="color" value="{{ $filters['color'] }}">
+    </div>
+    <div class="col-md-2">
+        <button class="btn btn-secondary w-100" type="submit">Filter</button>
+    </div>
 </form>
-<ul>
+
+<div class="row row-cols-1 g-3">
 {% foreach ($notes as $note) { %}
-    <li style="border-left: 4px solid {{ $note->getColor() }}; margin:5px; padding:5px;">
-        <strong>{{ $note->getTitle() }}</strong> - {{ $note->getDescription() }}<br>
-        <small>Tags: {{ $note->getTags() }} | Created: {{ $note->getCreatedAt() }}</small><br>
-        <a href="/notes/edit?id={{ $note->getId() }}">Edit</a>
-        <a href="/notes/delete?id={{ $note->getId() }}">Delete</a>
-    </li>
+    <div class="col">
+        <div class="card" style="border-left: 6px solid {{ $note->getColor() }};">
+            <div class="card-body">
+                <h5 class="card-title">{{ $note->getTitle() }}</h5>
+                <p class="card-text">{{ $note->getDescription() }}</p>
+                <p class="card-text"><small class="text-muted">Tags: {{ $note->getTags() }} | Created: {{ $note->getCreatedAt() }}</small></p>
+                <a class="btn btn-sm btn-outline-primary" href="/notes/edit?id={{ $note->getId() }}">Edit</a>
+                <a class="btn btn-sm btn-outline-danger" href="/notes/delete?id={{ $note->getId() }}">Delete</a>
+            </div>
+        </div>
+    </div>
 {% } %}
-</ul>
+</div>
 {% endblock %}

--- a/views/notes/success.html
+++ b/views/notes/success.html
@@ -1,6 +1,8 @@
 {% extends layout.html %}
 {% block title %}Success{% endblock %}
 {% block content %}
-<h1>Success!</h1>
-<a href="/notes">Back</a>
+<div class="alert alert-success" role="alert">
+    Success!
+</div>
+<a class="btn btn-link" href="/notes">Back</a>
 {% endblock %}

--- a/views/notes/success.html
+++ b/views/notes/success.html
@@ -1,0 +1,6 @@
+{% extends layout.html %}
+{% block title %}Success{% endblock %}
+{% block content %}
+<h1>Success!</h1>
+<a href="/notes">Back</a>
+{% endblock %}

--- a/web/404.html
+++ b/web/404.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>Страница не найдена</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
-<img src="/img/404.jpg" alt="Упс! Страница не найдена">
+<body class="d-flex flex-column align-items-center justify-content-center vh-100">
+<img class="img-fluid mb-3" src="/img/404.jpg" alt="Упс! Страница не найдена">
+<a class="btn btn-primary" href="/notes">Go back</a>
 </body>
 </html>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1,0 +1,3 @@
+.card {
+    border-left-width: .5rem;
+}

--- a/web/index.php
+++ b/web/index.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use app\controllers\PresentationController;
+use app\controllers\NoteController;
 use app\core\Application;
 use app\core\ConfigParser;
 
@@ -26,8 +27,19 @@ $application = new Application();
 
 $router = $application->getRouter();
 
-$router->setGetRoute("/", [new PresentationController(), "getView"]);
-$router->setPostRoute("/handle", [new PresentationController(), "handleView"]);
+$presentation = new PresentationController();
+$notes = new NoteController();
+
+$router->setGetRoute("/", [$notes, "index"]);
+$router->setGetRoute("/notes", [$notes, "index"]);
+$router->setGetRoute("/notes/create", [$notes, "createView"]);
+$router->setPostRoute("/notes/create", [$notes, "create"]);
+$router->setGetRoute("/notes/edit", [$notes, "editView"]);
+$router->setPostRoute("/notes/edit", [$notes, "edit"]);
+$router->setGetRoute("/notes/delete", [$notes, "delete"]);
+
+$router->setGetRoute("/presentation", [$presentation, "getView"]);
+$router->setPostRoute("/handle", [$presentation, "handleView"]);
 $router->setGetRoute("/error", "");
 
 ob_start();


### PR DESCRIPTION
## Summary
- add `Note` model and data mapper
- enable query string support in Request
- update migrations for notes table
- add controller and views for CRUD operations
- register note routes in web entrypoint

## Testing
- `php` not available so no automated tests run

------
https://chatgpt.com/codex/tasks/task_e_6851b470dca88329a51a4bb3ae2bf474