### PR TITLE
Add registration and authentication

### DIFF
--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\controllers;
+
+use app\core\Application;
+use app\mappers\AuthMapper;
+use app\models\AuthUser;
+
+class AuthController
+{
+    private AuthMapper $mapper;
+
+    public function __construct()
+    {
+        $this->mapper = new AuthMapper();
+    }
+
+    public function registerView(): void
+    {
+        Application::$app->getRouter()->renderTemplate('auth/register');
+    }
+
+    public function register(): void
+    {
+        $body = Application::$app->getRequest()->getBody();
+        $login = $body['login'] ?? '';
+        $password = $body['password'] ?? '';
+        if ($login === '' || $password === '') {
+            Application::$app->getRouter()->renderTemplate('auth/register', ['error' => 'Fill all fields']);
+            return;
+        }
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $user = new AuthUser(null, $login, $hash);
+        $this->mapper->Insert($user);
+        Application::$app->login($user);
+        header('Location: /notes');
+    }
+
+    public function loginView(): void
+    {
+        Application::$app->getRouter()->renderTemplate('auth/login');
+    }
+
+    public function login(): void
+    {
+        $body = Application::$app->getRequest()->getBody();
+        $login = $body['login'] ?? '';
+        $password = $body['password'] ?? '';
+        $user = $this->mapper->getByLogin($login);
+        if (!$user || !password_verify($password, $user->getPassword())) {
+            Application::$app->getRouter()->renderTemplate('auth/login', ['error' => 'Invalid credentials']);
+            return;
+        }
+        Application::$app->login($user);
+        header('Location: /notes');
+    }
+
+    public function logout(): void
+    {
+        Application::$app->logout();
+        header('Location: /login');
+    }
+}

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -27,12 +27,14 @@ class AuthController
         $body = Application::$app->getRequest()->getBody();
         $login = $body['login'] ?? '';
         $password = $body['password'] ?? '';
-        if ($login === '' || $password === '') {
+        $first = $body['first_name'] ?? '';
+        $second = $body['second_name'] ?? '';
+        if ($login === '' || $password === '' || $first === '' || $second === '') {
             Application::$app->getRouter()->renderTemplate('auth/register', ['error' => 'Fill all fields']);
             return;
         }
         $hash = password_hash($password, PASSWORD_DEFAULT);
-        $user = new AuthUser(null, $login, $hash);
+        $user = new AuthUser(null, $login, $hash, $first, $second);
         $this->mapper->Insert($user);
         Application::$app->login($user);
         header('Location: /notes');

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -37,8 +37,7 @@ class AuthController
         $user = new AuthUser(null, $login, $hash, $first, $second);
         $this->mapper->Insert($user);
         Application::$app->login($user);
-        header('Location: /notes');
-        exit;
+        Application::$app->getResponse()->redirect('/notes');
     }
 
     public function loginView(): void
@@ -57,14 +56,12 @@ class AuthController
             return;
         }
         Application::$app->login($user);
-        header('Location: /notes');
-        exit;
+        Application::$app->getResponse()->redirect('/notes');
     }
 
     public function logout(): void
     {
         Application::$app->logout();
-        header('Location: /login');
-        exit;
+        Application::$app->getResponse()->redirect('/login');
     }
 }

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -38,6 +38,7 @@ class AuthController
         $this->mapper->Insert($user);
         Application::$app->login($user);
         header('Location: /notes');
+        exit;
     }
 
     public function loginView(): void
@@ -57,11 +58,13 @@ class AuthController
         }
         Application::$app->login($user);
         header('Location: /notes');
+        exit;
     }
 
     public function logout(): void
     {
         Application::$app->logout();
         header('Location: /login');
+        exit;
     }
 }

--- a/controllers/NoteController.php
+++ b/controllers/NoteController.php
@@ -17,13 +17,25 @@ class NoteController
         $this->mapper = new NoteMapper();
     }
 
+    private function requireLogin(): ?\app\models\AuthUser
+    {
+        $user = Application::$app->getUser();
+        if (!$user) {
+            header('Location: /login');
+            exit;
+        }
+        $this->mapper->setUserId($user->getId());
+        return $user;
+    }
+
     public function index(): void
     {
+        $user = $this->requireLogin();
         $body = Application::$app->getRequest()->getBody();
         $query = $body['q'] ?? null;
         $tag = $body['tag'] ?? null;
         $color = $body['color'] ?? null;
-        $rows = $this->mapper->filter($query, $tag, $color);
+        $rows = $this->mapper->filter($user->getId(), $query, $tag, $color);
         $notes = array_map(fn($row) => $this->mapper->createObject($row), $rows);
         Application::$app->getRouter()->renderTemplate('notes/index', [
             'notes' => $notes,
@@ -33,6 +45,7 @@ class NoteController
 
     public function createView(): void
     {
+        $this->requireLogin();
         Application::$app->getRouter()->renderTemplate('notes/form', [
             'action' => '/notes/create',
             'title' => '',
@@ -46,9 +59,11 @@ class NoteController
 
     public function create(): void
     {
+        $user = $this->requireLogin();
         $body = Application::$app->getRequest()->getBody();
         $note = new Note(
             id: null,
+            user_id: $user->getId(),
             title: $body['title'] ?? '',
             description: $body['description'] ?? '',
             color: $body['color'] ?? '',
@@ -60,6 +75,7 @@ class NoteController
 
     public function editView(): void
     {
+        $user = $this->requireLogin();
         $body = Application::$app->getRequest()->getBody();
         if (!isset($body['id'])) {
             Application::$app->getRouter()->renderStatic('404.html');
@@ -85,6 +101,7 @@ class NoteController
 
     public function edit(): void
     {
+        $user = $this->requireLogin();
         $body = Application::$app->getRequest()->getBody();
         if (!isset($body['id'])) {
             Application::$app->getRouter()->renderStatic('404.html');
@@ -92,6 +109,7 @@ class NoteController
         }
         $note = new Note(
             id: (int)$body['id'],
+            user_id: $user->getId(),
             title: $body['title'] ?? '',
             description: $body['description'] ?? '',
             color: $body['color'] ?? '',
@@ -103,9 +121,10 @@ class NoteController
 
     public function delete(): void
     {
+        $user = $this->requireLogin();
         $body = Application::$app->getRequest()->getBody();
         if (isset($body['id'])) {
-            $note = new Note((int)$body['id'], '', '', '', '');
+            $note = new Note((int)$body['id'], $user->getId(), '', '', '', '');
             $this->mapper->Delete($note);
         }
         Application::$app->getRouter()->renderTemplate('notes/success', []);

--- a/controllers/NoteController.php
+++ b/controllers/NoteController.php
@@ -21,8 +21,7 @@ class NoteController
     {
         $user = Application::$app->getUser();
         if (!$user) {
-            header('Location: /login');
-            exit;
+            Application::$app->getResponse()->redirect('/login');
         }
         $this->mapper->setUserId($user->getId());
         return $user;

--- a/core/Application.php
+++ b/core/Application.php
@@ -12,15 +12,22 @@ class Application
     private Router $router;
     private Logger $logger;
     private Database $database;
+    private ?\app\models\AuthUser $user = null;
 
     public function __construct()
     {
         self::$app = $this;
+        session_start();
         $this->logger = new Logger(sprintf("%sruntime/%s", PROJECT_ROOT, $_ENV["APP_LOG"]));
         $this->request = new Request();
         $this->response = new Response();
         $this->router = new Router($this->request, $this->response);
         $this->database = new Database(getenv("DB_DSN"), getenv("DB_USER"), getenv("DB_PASSWORD"));
+
+        if (isset($_SESSION['user_id'])) {
+            $mapper = new \app\mappers\AuthMapper();
+            $this->user = $mapper->Select((int)$_SESSION['user_id']);
+        }
 
     }
 
@@ -59,5 +66,22 @@ class Application
     public function getDatabase(): Database
     {
         return $this->database;
+    }
+
+    public function login(\app\models\AuthUser $user): void
+    {
+        $_SESSION['user_id'] = $user->getId();
+        $this->user = $user;
+    }
+
+    public function logout(): void
+    {
+        unset($_SESSION['user_id']);
+        $this->user = null;
+    }
+
+    public function getUser(): ?\app\models\AuthUser
+    {
+        return $this->user;
     }
 }

--- a/core/Application.php
+++ b/core/Application.php
@@ -47,6 +47,11 @@ class Application
         return $this->request;
     }
 
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
     public function getRouter(): Router
     {
         return $this->router;

--- a/core/Request.php
+++ b/core/Request.php
@@ -13,6 +13,10 @@ class Request
         if ($pos !== false) {
             $uri = substr($uri, 0, $pos);
         }
+        $uri = rtrim($uri, '/');
+        if ($uri === '') {
+            $uri = '/';
+        }
         return $uri;
     }
 

--- a/core/Response.php
+++ b/core/Response.php
@@ -10,4 +10,10 @@ class Response
    {
        \http_response_code($status->value);
    }
+
+   public function redirect(string $url): void
+   {
+       header("Location: $url");
+       exit;
+   }
 }

--- a/mappers/AuthMapper.php
+++ b/mappers/AuthMapper.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\mappers;
+
+use app\core\Mapper;
+use app\core\Model;
+use app\models\AuthUser;
+
+class AuthMapper extends Mapper
+{
+    private ?\PDOStatement $insert;
+    private ?\PDOStatement $select;
+    private ?\PDOStatement $selectByLogin;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->insert = $this->getPdo()->prepare(
+            "INSERT INTO users (login, password) VALUES (:login, :password)"
+        );
+        $this->select = $this->getPdo()->prepare("SELECT * FROM users WHERE id = :id");
+        $this->selectByLogin = $this->getPdo()->prepare("SELECT * FROM users WHERE login = :login");
+    }
+
+    protected function doInsert(Model $model): Model
+    {
+        /** @var AuthUser $model */
+        $this->insert->execute([
+            ':login' => $model->getLogin(),
+            ':password' => $model->getPassword(),
+        ]);
+        $model->setId((int)$this->getPdo()->lastInsertId());
+        return $model;
+    }
+
+    protected function doUpdate(Model $model)
+    {
+        // not implemented
+    }
+
+    protected function doDelete(Model $model)
+    {
+        // not implemented
+    }
+
+    public function doSelect(int $id): array
+    {
+        $this->select->execute([':id' => $id]);
+        return $this->select->fetch(\PDO::FETCH_ASSOC) ?: [];
+    }
+
+    protected function doSelectAll(): array
+    {
+        return [];
+    }
+
+    public function getInstance(): Mapper
+    {
+        return $this;
+    }
+
+    public function createObject(array $data): Model
+    {
+        return new AuthUser(
+            id: $data['id'] ?? null,
+            login: $data['login'] ?? '',
+            password: $data['password'] ?? ''
+        );
+    }
+
+    public function getByLogin(string $login): ?AuthUser
+    {
+        $this->selectByLogin->execute([':login' => $login]);
+        $row = $this->selectByLogin->fetch(\PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+        return $this->createObject($row);
+    }
+}

--- a/mappers/AuthMapper.php
+++ b/mappers/AuthMapper.php
@@ -18,7 +18,8 @@ class AuthMapper extends Mapper
     {
         parent::__construct();
         $this->insert = $this->getPdo()->prepare(
-            "INSERT INTO users (login, password) VALUES (:login, :password)"
+            "INSERT INTO users (login, password, first_name, second_name) " .
+            "VALUES (:login, :password, :first_name, :second_name)"
         );
         $this->select = $this->getPdo()->prepare("SELECT * FROM users WHERE id = :id");
         $this->selectByLogin = $this->getPdo()->prepare("SELECT * FROM users WHERE login = :login");
@@ -30,6 +31,8 @@ class AuthMapper extends Mapper
         $this->insert->execute([
             ':login' => $model->getLogin(),
             ':password' => $model->getPassword(),
+            ':first_name' => $model->getFirstName(),
+            ':second_name' => $model->getSecondName(),
         ]);
         $model->setId((int)$this->getPdo()->lastInsertId());
         return $model;
@@ -66,7 +69,9 @@ class AuthMapper extends Mapper
         return new AuthUser(
             id: $data['id'] ?? null,
             login: $data['login'] ?? '',
-            password: $data['password'] ?? ''
+            password: $data['password'] ?? '',
+            first_name: $data['first_name'] ?? '',
+            second_name: $data['second_name'] ?? ''
         );
     }
 

--- a/mappers/NoteMapper.php
+++ b/mappers/NoteMapper.php
@@ -10,6 +10,7 @@ use app\models\Note;
 
 class NoteMapper extends Mapper
 {
+    private int $userId = 0;
     private ?\PDOStatement $insert;
     private ?\PDOStatement $update;
     private ?\PDOStatement $delete;
@@ -21,18 +22,17 @@ class NoteMapper extends Mapper
         parent::__construct();
 
         $this->insert = $this->getPdo()->prepare(
-            "INSERT INTO notes (title, description, color, tags) VALUES (:title, :description, :color, :tags)"
+            "INSERT INTO notes (title, description, color, tags, user_id) VALUES (:title, :description, :color, :tags, :user_id)"
         );
 
         $this->update = $this->getPdo()->prepare(
-            "UPDATE notes SET title = :title, description = :description, color = :color, tags = :tags, updated_at = current_timestamp WHERE id = :id"
+            "UPDATE notes SET title = :title, description = :description, color = :color, tags = :tags, updated_at = current_timestamp WHERE id = :id AND user_id = :user_id"
         );
 
-        $this->delete = $this->getPdo()->prepare("DELETE FROM notes WHERE id = :id");
+        $this->delete = $this->getPdo()->prepare("DELETE FROM notes WHERE id = :id AND user_id = :user_id");
 
-        $this->select = $this->getPdo()->prepare("SELECT * FROM notes WHERE id = :id");
-
-        $this->selectAll = $this->getPdo()->prepare("SELECT * FROM notes ORDER BY created_at DESC");
+        $this->select = $this->getPdo()->prepare("SELECT * FROM notes WHERE id = :id AND user_id = :user_id");
+        $this->selectAll = $this->getPdo()->prepare("SELECT * FROM notes WHERE user_id = :user_id ORDER BY created_at DESC");
     }
 
     protected function doInsert(Model $model): Model
@@ -43,6 +43,7 @@ class NoteMapper extends Mapper
             ':description' => $model->getDescription(),
             ':color' => $model->getColor(),
             ':tags' => $model->getTags(),
+            ':user_id' => $model->getUserId(),
         ]);
         $model->setId((int)$this->getPdo()->lastInsertId());
         return $model;
@@ -57,23 +58,24 @@ class NoteMapper extends Mapper
             ':description' => $model->getDescription(),
             ':color' => $model->getColor(),
             ':tags' => $model->getTags(),
+            ':user_id' => $model->getUserId(),
         ]);
     }
 
     protected function doDelete(Model $model)
     {
-        $this->delete->execute([':id' => $model->getId()]);
+        $this->delete->execute([':id' => $model->getId(), ':user_id' => $model->getUserId()]);
     }
 
     public function doSelect(int $id): array
     {
-        $this->select->execute([':id' => $id]);
+        $this->select->execute([':id' => $id, ':user_id' => $this->userId]);
         return $this->select->fetch(\PDO::FETCH_ASSOC) ?: [];
     }
 
     protected function doSelectAll(): array
     {
-        $this->selectAll->execute();
+        $this->selectAll->execute([':user_id' => $this->userId]);
         return $this->selectAll->fetchAll(\PDO::FETCH_ASSOC);
     }
 
@@ -82,10 +84,16 @@ class NoteMapper extends Mapper
         return $this;
     }
 
+    public function setUserId(int $userId): void
+    {
+        $this->userId = $userId;
+    }
+
     public function createObject(array $data): Model
     {
         return new Note(
             id: $data['id'] ?? null,
+            user_id: $data['user_id'] ?? 0,
             title: $data['title'] ?? '',
             description: $data['description'] ?? '',
             color: $data['color'] ?? '',
@@ -95,10 +103,10 @@ class NoteMapper extends Mapper
         );
     }
 
-    public function filter(?string $query = null, ?string $tag = null, ?string $color = null): array
+    public function filter(int $userId, ?string $query = null, ?string $tag = null, ?string $color = null): array
     {
-        $sql = 'SELECT * FROM notes WHERE 1=1';
-        $params = [];
+        $sql = 'SELECT * FROM notes WHERE user_id = :user_id';
+        $params = [':user_id' => $userId];
         if ($query) {
             $sql .= ' AND (title ILIKE :query OR description ILIKE :query)';
             $params[':query'] = '%' . $query . '%';

--- a/migrations/AllMigrations.php
+++ b/migrations/AllMigrations.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use app\migrations\{Migration_0, Migration_1, Migration_2, Migration_3};
+use app\migrations\{Migration_0, Migration_1, Migration_2, Migration_3, Migration_4};
 
 function getMigrations(): array
 {
-    return [new Migration_0(), new Migration_1(), new Migration_2(), new Migration_3()];
+    return [new Migration_0(), new Migration_1(), new Migration_2(), new Migration_3(), new Migration_4()];
 }

--- a/migrations/Migration_4.php
+++ b/migrations/Migration_4.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\migrations;
+
+class Migration_4 extends \app\core\Migration
+{
+    public function getVersion(): int
+    {
+        return 4;
+    }
+
+    public function up(): void
+    {
+        // add login and password columns to users table
+        $this->database->pdo->query("ALTER TABLE users ADD COLUMN IF NOT EXISTS login varchar(255) UNIQUE;");
+        $this->database->pdo->query("ALTER TABLE users ADD COLUMN IF NOT EXISTS password varchar(255);");
+
+        // link notes to users
+        $this->database->pdo->query("ALTER TABLE notes ADD COLUMN IF NOT EXISTS user_id int REFERENCES users(id);");
+
+        parent::up();
+    }
+}

--- a/models/AuthUser.php
+++ b/models/AuthUser.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use app\core\Model;
+
+class AuthUser extends Model
+{
+    private string $login;
+    private string $password;
+
+    public function __construct(?int $id, string $login, string $password)
+    {
+        parent::__construct($id);
+        $this->login = $login;
+        $this->password = $password;
+    }
+
+    public function getLogin(): string
+    {
+        return $this->login;
+    }
+
+    public function setLogin(string $login): void
+    {
+        $this->login = $login;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): void
+    {
+        $this->password = $password;
+    }
+}

--- a/models/AuthUser.php
+++ b/models/AuthUser.php
@@ -10,12 +10,21 @@ class AuthUser extends Model
 {
     private string $login;
     private string $password;
+    private string $first_name;
+    private string $second_name;
 
-    public function __construct(?int $id, string $login, string $password)
-    {
+    public function __construct(
+        ?int $id,
+        string $login,
+        string $password,
+        string $first_name,
+        string $second_name
+    ) {
         parent::__construct($id);
         $this->login = $login;
         $this->password = $password;
+        $this->first_name = $first_name;
+        $this->second_name = $second_name;
     }
 
     public function getLogin(): string
@@ -36,5 +45,25 @@ class AuthUser extends Model
     public function setPassword(string $password): void
     {
         $this->password = $password;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->first_name;
+    }
+
+    public function setFirstName(string $first_name): void
+    {
+        $this->first_name = $first_name;
+    }
+
+    public function getSecondName(): string
+    {
+        return $this->second_name;
+    }
+
+    public function setSecondName(string $second_name): void
+    {
+        $this->second_name = $second_name;
     }
 }

--- a/models/Note.php
+++ b/models/Note.php
@@ -8,6 +8,7 @@ use app\core\Model;
 
 class Note extends Model
 {
+    private int $user_id;
     private string $title;
     private string $description;
     private string $color;
@@ -16,6 +17,7 @@ class Note extends Model
     private string $updated_at;
 
     public function __construct(?int $id,
+                                int $user_id,
                                 string $title,
                                 string $description,
                                 string $color,
@@ -24,12 +26,23 @@ class Note extends Model
                                 string $updated_at = '')
     {
         parent::__construct($id);
+        $this->user_id = $user_id;
         $this->title = $title;
         $this->description = $description;
         $this->color = $color;
         $this->tags = $tags;
         $this->created_at = $created_at;
         $this->updated_at = $updated_at;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->user_id;
+    }
+
+    public function setUserId(int $user_id): void
+    {
+        $this->user_id = $user_id;
     }
 
     public function getTitle(): string

--- a/views/auth/login.html
+++ b/views/auth/login.html
@@ -1,0 +1,21 @@
+{% extends layout.html %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+<h2 class="mb-3">Login</h2>
+{% if (isset($error)) { %}
+<div class="alert alert-danger">{{ $error }}</div>
+{% } %}
+<form method="post" action="/login">
+    <div class="mb-3">
+        <label class="form-label">Login</label>
+        <input class="form-control" type="text" name="login">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input class="form-control" type="password" name="password">
+    </div>
+    <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}

--- a/views/auth/register.html
+++ b/views/auth/register.html
@@ -9,6 +9,14 @@
 {% } %}
 <form method="post" action="/register">
     <div class="mb-3">
+        <label class="form-label">First Name</label>
+        <input class="form-control" type="text" name="first_name">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Second Name</label>
+        <input class="form-control" type="text" name="second_name">
+    </div>
+    <div class="mb-3">
         <label class="form-label">Login</label>
         <input class="form-control" type="text" name="login">
     </div>

--- a/views/auth/register.html
+++ b/views/auth/register.html
@@ -1,0 +1,21 @@
+{% extends layout.html %}
+
+{% block title %}Register{% endblock %}
+
+{% block content %}
+<h2 class="mb-3">Register</h2>
+{% if (isset($error)) { %}
+<div class="alert alert-danger">{{ $error }}</div>
+{% } %}
+<form method="post" action="/register">
+    <div class="mb-3">
+        <label class="form-label">Login</label>
+        <input class="form-control" type="text" name="login">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input class="form-control" type="password" name="password">
+    </div>
+    <button class="btn btn-primary" type="submit">Register</button>
+</form>
+{% endblock %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -10,6 +10,16 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
     <div class="container">
         <a class="navbar-brand" href="/notes">Notes App</a>
+        {% $u = \app\core\Application::$app->getUser(); %}
+        <div class="d-flex ms-auto">
+        {% if ($u) { %}
+            <span class="navbar-text me-2">{{ $u->getLogin() }}</span>
+            <a class="btn btn-outline-light" href="/logout">Logout</a>
+        {% } else { %}
+            <a class="btn btn-outline-light me-2" href="/login">Login</a>
+            <a class="btn btn-outline-light" href="/register">Register</a>
+        {% } %}
+        </div>
     </div>
 </nav>
 <div class="container mb-5">

--- a/web/index.php
+++ b/web/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use app\controllers\PresentationController;
 use app\controllers\NoteController;
+use app\controllers\AuthController;
 use app\core\Application;
 use app\core\ConfigParser;
 
@@ -29,6 +30,7 @@ $router = $application->getRouter();
 
 $presentation = new PresentationController();
 $notes = new NoteController();
+$auth = new AuthController();
 
 $router->setGetRoute("/", [$notes, "index"]);
 $router->setGetRoute("/notes", [$notes, "index"]);
@@ -37,6 +39,12 @@ $router->setPostRoute("/notes/create", [$notes, "create"]);
 $router->setGetRoute("/notes/edit", [$notes, "editView"]);
 $router->setPostRoute("/notes/edit", [$notes, "edit"]);
 $router->setGetRoute("/notes/delete", [$notes, "delete"]);
+
+$router->setGetRoute("/login", [$auth, "loginView"]);
+$router->setPostRoute("/login", [$auth, "login"]);
+$router->setGetRoute("/register", [$auth, "registerView"]);
+$router->setPostRoute("/register", [$auth, "register"]);
+$router->setGetRoute("/logout", [$auth, "logout"]);
 
 $router->setGetRoute("/presentation", [$presentation, "getView"]);
 $router->setPostRoute("/handle", [$presentation, "handleView"]);


### PR DESCRIPTION
## Summary
- add `AuthController` and templates for sign up and log in
- enable sessions and user login logic in Application
- add `AuthMapper` and `AuthUser` model
- track note ownership with user_id and secure CRUD in NoteController
- allow filtering notes only by current user
- create DB migration to extend `users` table and connect notes to users
- show login/register links in layout
- expose auth routes in entry point

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685316d5ffa883299b3e39a77b040e2d